### PR TITLE
fixing Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all:
 	test -f ${outfile} || wget ${srcfile}
 	unzip ${outfile}
 	mkdir ttf
-	mv JetBrainsMono-master/ttf/*.ttf ttf/
+	mv JetBrainsMono-master/fonts/ttf/*.ttf ttf/
 	rm -rf JetBrainsMono-master
 
 clean:


### PR DESCRIPTION
Hi Dirk,

I was following the `README` instructions to create the `.deb` file associated with this font and I was getting the same error over and over again. To make sure the problem was not my computer (or me), I tried to follow the same steps for another similar repo owned by you ([Source Code Pro](https://github.com/eddelbuettel/pkg-fonts-source-code-pro)) and it worked great.

Then, I investigated the error messages after running the `runMe.sh` script. It happened that I had to make a minor modification to the `Makefile` to make it work. My guess is that the directory structure of the JetBrain might have changed...

Anyways, now it is working, I hope this PR is helpful. 
Thank you for making your tricks to get these fonts available.